### PR TITLE
Set relative path in sha256 file

### DIFF
--- a/.github/workflows/image_build.yaml
+++ b/.github/workflows/image_build.yaml
@@ -129,7 +129,7 @@ jobs:
           
           FILE_PATH=$(basename $FILE_PATH)
           
-          sha256sum $FILE_PATH > $(basename $FILE_PATH).sha256
+          sha256sum $FILE_PATH > $FILE_PATH.sha256
 
           echo "FILE_PATH=$FILE_PATH" >> $GITHUB_ENV
           echo "FILE_SHA256=$FILE_PATH.sha256" >> $GITHUB_ENV

--- a/.github/workflows/image_build.yaml
+++ b/.github/workflows/image_build.yaml
@@ -127,10 +127,12 @@ jobs:
           FILE_PATH=$(find /var/cache/manjaro-arm-tools/img -type f -name "*.img.xz" -exec stat -c '%Y %n' {} \; | sort -nr | awk 'NR==1 {print $2}')
           cp -v $FILE_PATH .
           
+          FILE_PATH=$(basename $FILE_PATH)
+          
           sha256sum $FILE_PATH > $(basename $FILE_PATH).sha256
 
-          echo "FILE_PATH=$(basename $FILE_PATH)" >> $GITHUB_ENV
-          echo "FILE_SHA256=$(basename $FILE_PATH).sha256" >> $GITHUB_ENV
+          echo "FILE_PATH=$FILE_PATH" >> $GITHUB_ENV
+          echo "FILE_SHA256=$FILE_PATH.sha256" >> $GITHUB_ENV
           
           FILE_PKG=$(find /var/cache/manjaro-arm-tools/img -type f -name "*-pkgs.txt" -exec stat -c '%Y %n' {} \; | sort -nr | awk 'NR==1 {print $2}')
           cp -v $FILE_PKG .


### PR DESCRIPTION
Fix #2.
This should generate the sha256sum with the relative path of the image.